### PR TITLE
Upgrade com.google.guava to v30.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <!-- Dependency versions -->
         <springfox-swagger.version>2.8.0</springfox-swagger.version>
         <kubernetes.client-java.version>1.0.0-beta1</kubernetes.client-java.version>
-        <guava.version>22.0</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
     </properties>
 


### PR DESCRIPTION
Due to a moderate severity security update

https://github.com/elixir-cloud-aai/tesk-api/security/dependabot/pom.xml/com.google.guava:guava/open

we need to update com.google.guava