### PR TITLE
fix Sets the requests equals to limits.

### DIFF
--- a/src/main/java/uk/ac/ebi/tsc/tesk/k8s/convert/TesKubernetesConverter.java
+++ b/src/main/java/uk/ac/ebi/tsc/tesk/k8s/convert/TesKubernetesConverter.java
@@ -189,6 +189,7 @@ public class TesKubernetesConverter {
             executor.getEnv().forEach((key, value) -> container.addEnvItem(new V1EnvVar().name(key).value(value)));
         }
         container.setWorkingDir(executor.getWorkdir());
+        Optional.ofNullable(resources).map(TesResources::getCpuCores).ifPresent(cpuCores -> container.getResources().putLimitsItem(RESOURCE_CPU_KEY, new QuantityFormatter().parse(cpuCores.toString())));
         Optional.ofNullable(resources).map(TesResources::getCpuCores).ifPresent(cpuCores -> container.getResources().putRequestsItem(RESOURCE_CPU_KEY, new QuantityFormatter().parse(cpuCores.toString())));
 	// Limit number of decimals to 6
 	Optional.ofNullable(resources).map(TesResources::getRamGb).ifPresent(ramGb -> container.getResources().putRequestsItem(RESOURCE_MEM_KEY, new QuantityFormatter().parse(String.format("%.6f",ramGb)+RESOURCE_MEM_UNIT)));

--- a/src/test/java/uk/ac/ebi/tsc/tesk/k8s/convert/TesKubernetesConverterTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/k8s/convert/TesKubernetesConverterTest.java
@@ -241,6 +241,7 @@ public class TesKubernetesConverterTest {
         taskMasterInputJson.extractingJsonPathStringValue("executors[1].spec.template.spec.containers[0].name").isEqualTo("task-35605447-ex-01");
 
         taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.restartPolicy").containsOnly("Never").hasSize(2);
+        taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.containers[0].resources.limits.cpu").containsOnly("4").hasSize(2);
         taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.containers[0].resources.requests.cpu").containsOnly("4").hasSize(2);
         taskMasterInputJson.extractingJsonPathArrayValue("executors[*].spec.template.spec.containers[0].resources.requests.memory").containsOnly("16106127360").hasSize(2);
 
@@ -256,7 +257,7 @@ public class TesKubernetesConverterTest {
 
         taskMasterInputJson.extractingJsonPathNumberValue("resources.disk_gb").isEqualTo(100.0);
 
-        taskMasterInputJson.isEqualToJson(new ClassPathResource("fromTesToK8s/taskmaster_param.json"), JSONCompareMode.NON_EXTENSIBLE);
+        //taskMasterInputJson.isEqualToJson(new ClassPathResource("fromTesToK8s/taskmaster_param.json"), JSONCompareMode.NON_EXTENSIBLE);
 
     }
 

--- a/src/test/java/uk/ac/ebi/tsc/tesk/k8s/convert/TesKubernetesConverterTest.java
+++ b/src/test/java/uk/ac/ebi/tsc/tesk/k8s/convert/TesKubernetesConverterTest.java
@@ -257,7 +257,7 @@ public class TesKubernetesConverterTest {
 
         taskMasterInputJson.extractingJsonPathNumberValue("resources.disk_gb").isEqualTo(100.0);
 
-        //taskMasterInputJson.isEqualToJson(new ClassPathResource("fromTesToK8s/taskmaster_param.json"), JSONCompareMode.NON_EXTENSIBLE);
+        taskMasterInputJson.isEqualToJson(new ClassPathResource("fromTesToK8s/taskmaster_param.json"), JSONCompareMode.NON_EXTENSIBLE);
 
     }
 

--- a/src/test/resources/fromTesToK8s/taskmaster_param.json
+++ b/src/test/resources/fromTesToK8s/taskmaster_param.json
@@ -71,7 +71,7 @@
                     "memory": "16106127360"
                   },
                   "limits": {
-                    "cpu": 4
+                    "cpu": "4"
                   }
                 },
                 "volumeMounts": [
@@ -146,6 +146,9 @@
                   "requests": {
                     "cpu": "4",
                     "memory": "16106127360"
+                  },
+                  "limits": {
+                    "cpu": "4"
                   }
                 },
                 "workingDir": "/starthere",

--- a/src/test/resources/fromTesToK8s/taskmaster_param.json
+++ b/src/test/resources/fromTesToK8s/taskmaster_param.json
@@ -69,6 +69,9 @@
                   "requests": {
                     "cpu": "4",
                     "memory": "16106127360"
+                  },
+                  "limits": {
+                    "cpu": 4
                   }
                 },
                 "volumeMounts": [


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Set CPU limits in Kubernetes container resources to match CPU requests and update tests to verify this behavior.

Bug Fixes:
- Ensure that CPU limits are set in the Kubernetes container resources to match the CPU requests.

Tests:
- Add test assertions to verify that CPU limits are correctly set in the Kubernetes container resources.

<!-- Generated by sourcery-ai[bot]: end summary -->